### PR TITLE
fix: remove g_thread_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (unreleased)
 
+fix: remove `g_thread_init` (deprecation) ([#26](https://github.com/fofix/python-mixstream/pull/26))
 fix: replace `GStaticMutex` with `GMutex` (deprecation) ([#24](https://github.com/fofix/python-mixstream/pull/24))
 
 ## 1.0.0 (2022-03-03)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MixStream is a C-extension in Python to combine [SoundTouch](https://www.surina.
 
 You'll need those packages:
 
-* `glib`
+* `glib` ( > 2.34)
 * `libogg`
 * `libtheora`
 * `libvorbisfile`

--- a/mixstream/MixStream.c
+++ b/mixstream/MixStream.c
@@ -88,9 +88,6 @@ MixStream* mix_stream_new(int samprate, int channels, mix_stream_read_cb read_cb
 {
   MixStream* stream;
 
-  if (!g_thread_supported())
-    g_thread_init(NULL);
-
   stream = g_new0(MixStream, 1);
   stream->samprate = samprate;
   stream->channels = channels;


### PR DESCRIPTION
With GLib 2.34.3+, `g_thread_init` is deprecated and should be removed.

Ref #3