### PR TITLE
fix: replace `g_mutex_free` with `g_mutex_clear`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: remove `g_thread_init` (deprecation) ([#26](https://github.com/fofix/python-mixstream/pull/26))
 - fix: replace `GStaticMutex` with `GMutex` (deprecation) ([#24](https://github.com/fofix/python-mixstream/pull/24))
+- fix: replace `g_mutex_free` with `g_mutex_clear` to free resources (deprecation) ([#29](https://github.com/fofix/python-mixstream/pull/29))
 - fix: replace `g_mutex_new` with `g_mutex_init` to init a mutex (deprecation) ([#28](https://github.com/fofix/python-mixstream/pull/28))
 
 ## 1.0.0 (2022-03-03)

--- a/mixstream/MixStream.c
+++ b/mixstream/MixStream.c
@@ -146,7 +146,7 @@ void mix_stream_destroy(MixStream* stream)
 {
   if (stream->channel != -1)
     mix_stream_stop(stream);
-  g_mutex_free(&stream->st_mutex);
+  g_mutex_clear(&stream->st_mutex);
   if (stream->soundtouch != NULL)
     soundtouch_delete(stream->soundtouch);
   if (stream->free_cb != NULL)


### PR DESCRIPTION
To free resources allocated to the mutex, `g_mutex_free` is deprecated.

Ref #1