### PR TITLE
fix: replace `g_memdup` with `g_memdup2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: remove `g_thread_init` (deprecation) ([#26](https://github.com/fofix/python-mixstream/pull/26))
 - fix: replace `GStaticMutex` with `GMutex` (deprecation) ([#24](https://github.com/fofix/python-mixstream/pull/24))
+- fix: replace `g_memdup` with `g_memdup2` (deprecation) ([#30](https://github.com/fofix/python-mixstream/pull/30))
 - fix: replace `g_mutex_free` with `g_mutex_clear` to free resources (deprecation) ([#29](https://github.com/fofix/python-mixstream/pull/29))
 - fix: replace `g_mutex_new` with `g_mutex_init` to init a mutex (deprecation) ([#28](https://github.com/fofix/python-mixstream/pull/28))
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MixStream is a C-extension in Python to combine [SoundTouch](https://www.surina.
 
 You'll need those packages:
 
-* `glib` ( > 2.34)
+* `glib` (>= 2.68)
 * `libogg`
 * `libtheora`
 * `libvorbisfile`

--- a/mixstream/MixStream.c
+++ b/mixstream/MixStream.c
@@ -352,7 +352,7 @@ int mix_stream_play(MixStream* stream, int requested_channel)
   /* Now we know what channel we're on. Put it into the channel table. */
   g_mutex_lock(&chan_table_mutex);
   stream->channel = real_channel;
-  g_hash_table_insert(chan_table, g_memdup(&stream->channel, sizeof(int)), stream);
+  g_hash_table_insert(chan_table, g_memdup2(&stream->channel, sizeof(int)), stream);
   g_mutex_unlock(&chan_table_mutex);
 
   stream->chunk_start_ticks = SDL_GetTicks();


### PR DESCRIPTION
`g_memdup` is deprecated.

Ref #25